### PR TITLE
Port of thud

### DIFF
--- a/conf/bblayers.conf
+++ b/conf/bblayers.conf
@@ -18,7 +18,7 @@ BASELAYERS ?= " \
   ${OEROOT}/layers/meta-openembedded/meta-python \
   ${OEROOT}/layers/meta-virtualization \
   ${OEROOT}/layers/meta-ledge/meta-ledge-sw \
-  ${OEROOT}/layers/meta-updater/ \
+  ${OEROOT}/layers/meta-clang \
 "
 
 # These layers hold machine specific content, aka Board Support Packages
@@ -27,7 +27,6 @@ BSPLAYERS ?= " \
   ${OEROOT}/layers/meta-freescale-3rdparty \
   ${OEROOT}/layers/meta-ti \
   ${OEROOT}/layers/meta-ledge/meta-ledge-bsp \
-  ${OEROOT}/layers/meta-yocto/meta-yocto-bsp \
 "
 
 # Add your overlay location to EXTRALAYERS
@@ -37,6 +36,7 @@ EXTRALAYERS ?= " \
   ${OEROOT}/layers/meta-linaro/meta-linaro-toolchain \
   ${OEROOT}/layers/meta-linaro/meta-aarch64 \
   ${OEROOT}/layers/meta-linaro/meta-optee \
+  ${OEROOT}/layers/meta-updater/ \
 "
 
 BBLAYERS = " \

--- a/conf/local.conf
+++ b/conf/local.conf
@@ -47,5 +47,3 @@ PARALLEL_MAKE ?= "-j ${@oe.utils.cpu_count()}"
 # its good for a case when this is the only builder
 # generating the feeds
 #PRSERV_HOST = "localhost:0"
-
-INHERIT += "sota"

--- a/default.xml
+++ b/default.xml
@@ -1,44 +1,24 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <manifest>
-
-  <default remote="github" revision="master" sync-j="4"/>
-
-  <remote fetch="http://git.yoctoproject.org" name="yocto"/>
   <remote fetch="https://github.com" name="github"/>
   <remote fetch="http://git.linaro.org" name="linaro"/>
-  <remote fetch="https://github.com/OpenSourceFoundries" name="OpenSourceFoundries" />
+  <remote fetch="http://git.yoctoproject.org" name="yocto"/>
 
+  <default remote="github" revision="thud" sync-j="4"/>
 
-  <project name="openembedded/bitbake" path="bitbake" revision="6a9d86998fdd42b13690f024af33b6bf36b9d028"/>
-  <project name="openembedded/openembedded-core" path="layers/openembedded-core" revision="6ecb10e3952af4a77bc79160ecd81117e97d022a"/>
-  <project name="openembedded/meta-openembedded" path="layers/meta-openembedded" revision="b0950aeff5b630256bb5e25ca15f4d59c115e7c1"/>
+  <project name="openembedded/bitbake" path="bitbake" revision="1.40"/>
+  <project name="openembedded/meta-linaro" path="layers/meta-linaro" remote="linaro" revision="edb7ffc2a121df7596385595abe75180296103e0"/>
+  <project name="openembedded/meta-openembedded" path="layers/meta-openembedded" revision="6094ae18c8a35e5cc9998ac39869390d7f3bb1e2"/>
+  <project name="openembedded/openembedded-core" path="layers/openembedded-core" revision="75cd4edaa8a42f76c0594ce26df05c7a51d620df"/>
 
-  <project remote="linaro" name="openembedded/meta-linaro" path="layers/meta-linaro" revision="282b47a10940c26854c1cca0ec40950192af16fc"/>
-  <!--project name="linaro-technologies/meta-ltd" path="layers/meta-ltd" revision="2b9370f35dd3b5f2dde2ae165095406547162ba6"/-->
-
-  <project name="git/meta-yocto" path="layers/meta-yocto" remote="yocto" revision="eb759d24a69da5d649386a333461f4f226920f0d"/>¬
-  <project name="git/meta-ti" path="layers/meta-ti" remote="yocto" revision="66769ae4a7a6ce3c5bf5085825aca423665eab41" branch="master" />
-  <project name="git/meta-virtualization" path="layers/meta-virtualization" remote="yocto" revision="43e4cd760f2ff1d4bca1ae18bac052db41716989" />
-
-  <project name="96boards/meta-rpb" path="layers/meta-rpb" remote="github" revision="sumo" />
-
-  <!-- BSP -->
-  <project name="Freescale/meta-freescale-3rdparty" path="layers/meta-freescale-3rdparty" revision="314291fb1083048a3553392feb8012853bf37570"/>
-  <project remote="yocto" name="git/meta-freescale" path="layers/meta-freescale" revision="4cb517972b520066fa064f47624635eb3ea41cb2"/>
-
-  <!-- LEDGE -->
-  <project remote="github" name="Linaro/meta-ledge" path="layers/meta-ledge" revision="b8323adbbf701b363e5e89f70659fa8d1d040c4e">
-        <linkfile dest="setup-environment" src="../../.repo/manifests/setup-environment"/>
- </project>
-
- <project remote="github" name="advancedtelematic/meta-updater" path="layers/meta-updater" revision="sumo"/>
- 
-  <!--osf
-  <project name="core-containers" path="containers/core-containers" remote="OpenSourceFoundries" revision="decce9f0e42cb9d20f1799f394efdf715ba72f21" />
-  <project name="extra-containers" path="containers/extra-containers" remote="OpenSourceFoundries" revision="692eb049814f9b6282a30f8f606f1d4e1790075b" />
-  <project name="gateway-containers" path="containers/gateway-containers" remote="OpenSourceFoundries" revision="87f961b280607b22630be4300be83c49e221d06f" />
-  <project name="meta-osf" path="layers/meta-osf" remote="OpenSourceFoundries" revision="99486d0c3af5dcb8363b635dc689b2bef3c333bd" />
-  <project name="meta-updater" path="layers/meta-updater" remote="OpenSourceFoundries" revision="29dd5029731d02f323adb760cc3b169feb66d475" />
-  -->
-
+  <project name="96boards/meta-rpb" path="layers/meta-rpb" revision="6154d8e23b59948e18fe1e423dc622731aa0112d""/>
+  <project name="Freescale/meta-freescale-3rdparty" path="layers/meta-freescale-3rdparty" revision="56021ac593b6a3f4ed7be351d8f4358a19d8e87a"/>
+  <project name="Linaro/meta-ledge" path="layers/meta-ledge" revision="d1a61067131b81e8d1e56466687fb0303340d86b>
+    <linkfile dest="setup-environment" src="../../.repo/manifests/setup-environment"/>
+  </project>
+  <project name="advancedtelematic/meta-updater" path="layers/meta-updater" revision="04892ec7c55a10f76f928803918d18d1aa7cf482"/>
+  <project name="git/meta-freescale" path="layers/meta-freescale" remote="yocto" revision="1ec2c308da65f7ad49b99a3100912ae0b5e1dac3"/>
+  <project name="git/meta-ti" path="layers/meta-ti" remote="yocto" revision="06192ea1216f7d18ebac005ac71cd259a67d703e"/>
+  <project name="git/meta-virtualization" path="layers/meta-virtualization" remote="yocto" revision="cf352d74935ec17964700f5b4f86f9a63b3a2183"/>
+  <project name="kraj/meta-clang" path="layers/meta-clang" revision="thud"/>
 </manifest>


### PR DESCRIPTION
- add meta-clang
- point on thud branch for meta-rpb
- update of stm32mp157c-dk2 bsp

Restriction: don't work under an enterprise proxy
(aktualizr tools make some ethernet request to amazone service during build)

Change-Id: If4df91332c8606512cca4789d9c4ec8ac5148f51
Signed-off-by: Christophe Priouzeau <christophe.priouzeau@st.com>