### PR TITLE
Add support of meta-security

### DIFF
--- a/conf/bblayers.conf
+++ b/conf/bblayers.conf
@@ -38,6 +38,10 @@ EXTRALAYERS ?= " \
   ${OEROOT}/layers/meta-linaro/meta-optee \
   ${OEROOT}/layers/meta-updater/ \
   ${OEROOT}/layers/meta-selinux/ \
+  ${OEROOT}/layers/meta-security/ \
+  ${OEROOT}/layers/meta-security/meta-tpm \
+  ${OEROOT}/layers/meta-openembedded/meta-perl \
+  ${OEROOT}/layers/meta-openembedded/meta-filesystems \
 "
 
 BBLAYERS = " \

--- a/default.xml
+++ b/default.xml
@@ -6,20 +6,21 @@
 
   <default remote="github" revision="7933fd19fe1df357df0532d3983c10d014e8d5f6" sync-j="4"/>
 
-  <project name="openembedded/bitbake" path="bitbake" revision="b59cb2bc63940b9ebd8288de7ca4b1d9e96e026c"/>
-  <project name="openembedded/meta-linaro" path="layers/meta-linaro" remote="linaro" revision="edb7ffc2a121df7596385595abe75180296103e0"/>
-  <project name="openembedded/meta-openembedded" path="layers/meta-openembedded" revision="6094ae18c8a35e5cc9998ac39869390d7f3bb1e2"/>
-  <project name="openembedded/openembedded-core" path="layers/openembedded-core" revision="75cd4edaa8a42f76c0594ce26df05c7a51d620df"/>
+  <project name="openembedded/bitbake" path="bitbake" revision="d89358c7b8aa69f12b8c384c4fdb493782633494"/>
+  <project name="openembedded/meta-linaro" path="layers/meta-linaro" remote="linaro" revision="0a94decea3bd2504590d1637eadff9d502c19ee2"/>
+  <project name="openembedded/meta-openembedded" path="layers/meta-openembedded" revision="2154631d355c425a8e98b4a9d336bf2558ecfd1b"/>
+  <project name="openembedded/openembedded-core" path="layers/openembedded-core" revision="ad0a553f0bbdbed5f78a27162289a1e358580dcc"/>
 
-  <project name="96boards/meta-rpb" path="layers/meta-rpb" revision="6154d8e23b59948e18fe1e423dc622731aa0112d"/>
-  <project name="Freescale/meta-freescale-3rdparty" path="layers/meta-freescale-3rdparty" revision="56021ac593b6a3f4ed7be351d8f4358a19d8e87a"/>
-  <project name="Linaro/meta-ledge" path="layers/meta-ledge" revision="1cb7b9d750112dbca3014deaa843948f5a1cfdc7">
+  <project name="96boards/meta-rpb" path="layers/meta-rpb" revision="3fd79952f8f193220ab0c7585a7bbf2d94633a6d"/>
+  <project name="Freescale/meta-freescale-3rdparty" path="layers/meta-freescale-3rdparty" revision="c4b5ac6b20e4245ce0630e9197313aaef999a331"/>
+  <project name="Linaro/meta-ledge" path="layers/meta-ledge" revision="3b0b5e57c16f7f7ae9ee115b90e995ae3e4227b0">
     <linkfile dest="setup-environment" src="../../.repo/manifests/setup-environment"/>
   </project>
-  <project name="advancedtelematic/meta-updater" path="layers/meta-updater" revision="04892ec7c55a10f76f928803918d18d1aa7cf482"/>
-  <project name="git/meta-freescale" path="layers/meta-freescale" remote="yocto" revision="1ec2c308da65f7ad49b99a3100912ae0b5e1dac3"/>
-  <project name="git/meta-ti" path="layers/meta-ti" remote="yocto" revision="06192ea1216f7d18ebac005ac71cd259a67d703e"/>
+  <project name="advancedtelematic/meta-updater" path="layers/meta-updater" revision="2d2e46834af68b1c22ad0a022001c117caa4929c"/>
+  <project name="git/meta-freescale" path="layers/meta-freescale" remote="yocto" revision="f5c932229c31b612cba38c2ed6f3c3ec6b800e92"/>
+  <project name="git/meta-ti" path="layers/meta-ti" remote="yocto" revision="3552ba9d39fb9ffec4fcf45534ef94999cf215be"/>
   <project name="git/meta-virtualization" path="layers/meta-virtualization" remote="yocto" revision="9e8c0c96b443828a255e7d6ca6291598347672ac"/>
   <project name="git/meta-selinux" path="layers/meta-selinux" remote="yocto" revision="fb6192aa2c5df8e80c5e6d4fa5448d574332f68f"/>
   <project name="kraj/meta-clang" path="layers/meta-clang" revision="7933fd19fe1df357df0532d3983c10d014e8d5f6"/>
+  <project name="git/meta-security" path="layers/meta-security" remote="yocto" revision="31dc4e7532fa7a82060e0b50e5eb8d0414aa7e93"/>
 </manifest>


### PR DESCRIPTION
- add meta-security for tpm2 tools
- meta-ledge: add qemu machine
- meta-ledge: update kernel to 5.1rc5
- meta-ledge: add tpm2 tools on ledge-gateway image

Change-Id: I4688b0a6841a00cd5e605089a2c041e7707c013e
Signed-off-by: Christophe Priouzeau <christophe.priouzeau@st.com>