### PR TITLE
ignore warning on patching file

### DIFF
--- a/setup-environment-internal
+++ b/setup-environment-internal
@@ -242,7 +242,7 @@ ln -sf "${MANIFESTS}" "${OEROOT}"/layers/
 
 echo "Applying ledge  patches"
 cd "${OEROOT}"/layers
-patch -p1 < ${MANIFESTS}/patches/*.patch
+patch -p1 --forward --reject-file=- < ${MANIFESTS}/patches/*.patch
 cd -
 
 DISTRO_DIRNAME=$(echo "${DISTRO}" | sed 's#[.-]#_#g')


### PR DESCRIPTION
to support repo sync we can not save current patch
event in the file. Just trying to forward apply it or
just skipp and error.

Signed-off-by: Maxim Uvarov <maxim.uvarov@linaro.org>