### PR TITLE
build: fix rawcopy for multiple bitbake instances

### DIFF
--- a/patches/0004-fix-rawcopy.patch
+++ b/patches/0004-fix-rawcopy.patch
@@ -1,0 +1,22 @@
+diff --git a/scripts/lib/wic/plugins/source/rawcopy.py b/scripts/lib/wic/plugins/source/rawcopy.py
+index 82970ce51b..bc7464ffb3 100644
+--- a/openembedded-core/scripts/lib/wic/plugins/source/rawcopy.py
++++ b/openembedded-core/scripts/lib/wic/plugins/source/rawcopy.py
+@@ -4,6 +4,7 @@
+ 
+ import logging
+ import os
++import random
+ 
+ from wic import WicError
+ from wic.pluginbase import SourcePlugin
+@@ -57,7 +58,8 @@ class RawCopyPlugin(SourcePlugin):
+             raise WicError("No file specified")
+ 
+         src = os.path.join(kernel_dir, source_params['file'])
+-        dst = os.path.join(cr_workdir, "%s.%s" % (source_params['file'], part.lineno))
++        #dst = os.path.join(cr_workdir, "%s.%s" % (source_params['file'], part.lineno))
++        dst = os.path.join(cr_workdir, "%s.%s" % (source_params['file'], random.randint(1, 1024)))
+ 
+         if not os.path.exists(os.path.dirname(dst)):
+             os.makedirs(os.path.dirname(dst))


### PR DESCRIPTION
rawcopy is trying to copy binary files on a temp file with a suffix
based on partition number and create the WIC image.
If we run multiple OE instances they end up randomly creating/removing
the file causing build failures. Temporarily use a rand int as the
destrination until we fix this properly upstream

Signed-off-by: Ilias Apalodimas <ilias.apalodimas@linaro.org>