### PR TITLE
README: Add short description for Secure Storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,15 @@ To make TPM operational do:
 ~ #
 ```
 
+6. Secure Storage on QEMU arm64
+Secure storage has been enabled for storage of UEFI variables on the
+QEMU arm64 platform. The feature uses the secure NOR
+flash(flash0) for storage of the variables. The variables are
+persistent across platform resets. However, running a cleanall of the
+trusted-firmware-a recipe removes the secure NOR flash file that had
+been created. A subsequent build of the trusted firmare recipe will
+generate the flash file afresh.
+
 Creating a local topic branch
 -----------------------------
 


### PR DESCRIPTION
Add a short description on the secure storage feature that is being
added on the QEMU arm64 platform. More specifically, highlight the
fact that the UEFI variables stored do not persist across a clean and
build cycle of the trusted firmware recipe.

Signed-off-by: Sughosh Ganu <sughosh.ganu@linaro.org>