### PR TITLE
update meta-secure-core layer to correctly sign images

### DIFF
--- a/default.xml
+++ b/default.xml
@@ -26,7 +26,7 @@
   <project name="kraj/meta-clang" path="layers/meta-clang" revision="e63d6f9abba5348e2183089d6ef5ea384d7ae8d8"/>
   <project name="git/meta-security" path="layers/meta-security" remote="yocto" revision="c74cc97641fd93e0e7a4383255e9a0ab3deaf9d7"/>
   <project name="git/meta-cloud-services" path="layers/meta-cloud-services" remote ="yocto" revision="e960e1d2d42db7b236616f31e5021998ea93867f"/>
-  <project name="jiazhang0/meta-secure-core" path="layers/meta-secure-core" revision="ac1ec689f28def471bad0016e3fd97aba361f64c"/>
+  <project name="jiazhang0/meta-secure-core" path="layers/meta-secure-core" revision="b9f183a416726e6a89ebceb7c56f3d1964ad8dc0"/>
   <project name="96boards/meta-96boards" path="layers/meta-96boards" revision="762e5e76ad1a5f385f845b09bde723edfcd09cba"/>
   <project name="git/meta-arm" path="layers/meta-arm" remote="yocto" revision="02c660521619ddb7a9495d65403aaa2636747ce8"/>
   <project name="meta-rust/meta-rust" path="layers/meta-rust" revision="53bfa324891966a2daf5d36dc13d4a43725aebed"/>

--- a/patches/0007-secure-core-add-dunfell-branch-compatible.patch
+++ b/patches/0007-secure-core-add-dunfell-branch-compatible.patch
@@ -1,0 +1,48 @@
+From 78fd08c9cea7fb71ea10114facf04d9774b0b384 Mon Sep 17 00:00:00 2001
+From: Maxim Uvarov <maxim.uvarov@linaro.org>
+Date: Sat, 15 May 2021 19:59:30 +0100
+Subject: [PATCH] secure-core: add dunfell branch compatible
+
+Signed-off-by: Maxim Uvarov <maxim.uvarov@linaro.org>
+---
+ meta-efi-secure-boot/conf/layer.conf | 2 +-
+ meta-signing-key/conf/layer.conf     | 2 +-
+ meta/conf/layer.conf                 | 2 +-
+ 3 files changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/meta-efi-secure-boot/conf/layer.conf b/meta-efi-secure-boot/conf/layer.conf
+index 4eb6813..5bb07e0 100644
+--- a/meta-secure-core/meta-efi-secure-boot/conf/layer.conf
++++ b/meta-secure-core/meta-efi-secure-boot/conf/layer.conf
+@@ -19,4 +19,4 @@ LAYERDEPENDS_efi-secure-boot = "\
+     perl-layer \
+ "
+ 
+-LAYERSERIES_COMPAT_efi-secure-boot = "hardknott"
++LAYERSERIES_COMPAT_efi-secure-boot = "hardknott dunfell"
+diff --git a/meta-signing-key/conf/layer.conf b/meta-signing-key/conf/layer.conf
+index 9176709..a76e599 100644
+--- a/meta-secure-core/meta-signing-key/conf/layer.conf
++++ b/meta-secure-core/meta-signing-key/conf/layer.conf
+@@ -13,7 +13,7 @@ BBLAYERS_LAYERINDEX_NAME_signing-key = "meta-signing-key"
+ 
+ LAYERDEPENDS_signing-key = "core"
+ 
+-LAYERSERIES_COMPAT_signing-key = "hardknott"
++LAYERSERIES_COMPAT_signing-key = "hardknott dunfell"
+ 
+ SIGNING_MODEL ??= "sample"
+ SAMPLE_MOK_SB_KEYS_DIR = "${LAYERDIR}/files/mok_sb_keys"
+diff --git a/meta/conf/layer.conf b/meta/conf/layer.conf
+index 0bb1795..4898ff1 100644
+--- a/meta-secure-core/meta/conf/layer.conf
++++ b/meta-secure-core/meta/conf/layer.conf
+@@ -15,4 +15,4 @@ LAYERDEPENDS_secure-core = "\
+     core \
+ "
+ 
+-LAYERSERIES_COMPAT_secure-core = "hardknott"
++LAYERSERIES_COMPAT_secure-core = "hardknott dunfell"
+-- 
+2.17.1
+


### PR DESCRIPTION
We need more fresh sbsign utility to correctly sign with
certificate arm zImage.

Signed-off-by: Maxim Uvarov <maxim.uvarov@linaro.org>
Change-Id: I9e81c0e8f735e3981a3f4c0b7ff954ce7e5abc38