### PR TITLE
Remove meta-optee layer from the build

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,27 @@
-Ledge-oe-manifest
+# ledge-oe-manifest
 
-This is the main manifest file to build the LEDGE Reference Platform from source. For detailed build environment
-and build instructions please refer to ledge-dev-howto.pdf (generated from https://github.com/Linaro/ledge-doc
+This is the main manifest file to build the LEDGE Reference Platform from
+source. For detailed build environment and build instructions please refer
+to ledge-dev-howto.pdf (generated from https://github.com/Linaro/ledge-doc
 sources).
 
 For advanced users quick steps to build are:
-1. repo init -u https://github.com/Linaro/ledge-oe-manifest.git -b master
-2. MACHINE=ledge-multi-armv7 DISTRO=rpb source ./setup-environment build-rpb-mc
-3. Follow printed instructions to build ledge-iot and ledge-gateway images.
-Note: supported MACHINEs are: ledge-multi-armv7, ledge-multi-armv8, ledge-qemux86-64
+1. `repo init -u https://github.com/Linaro/ledge-oe-manifest.git -b master`
+2. `MACHINE=ledge-multi-armv7 DISTRO=rpb source ./setup-environment
+   build-rpb-mc`
+3. Follow printed instructions to build `bitbake ledge-iot` and `bitbake
+   ledge-gateway` images.
 
-User guide to run pre-built binaries is at ledge-user-guide.pdf (generated from https://github.com/Linaro/ledge-doc).
+Note: supported MACHINEs are: ledge-multi-armv7, ledge-multi-armv8,
+ledge-qemux86-64.
+
+User guide to run pre-built binaries is at ledge-user-guide.pdf (generated
+from https://github.com/Linaro/ledge-doc).
 
 CI system is located at https://ci.linaro.org/job/ledge-oe
+
+This manifest is usually used in conjunction with trusted substrate generated
+firmware. More info on trusted substrate can be found
+https://git.codelinaro.org/linaro/dependable-boot/meta-ts
 
 Mailing list: team-ledge@linaro.org

--- a/conf/bblayers.conf
+++ b/conf/bblayers.conf
@@ -33,7 +33,6 @@ BSPLAYERS ?= " \
 # Make sure to have a conf/layers.conf in there
 EXTRALAYERS ?= " \
   ${OEROOT}/layers/meta-linaro/meta-linaro \
-  ${OEROOT}/layers/meta-linaro/meta-optee \
   ${OEROOT}/layers/meta-updater/ \
   ${OEROOT}/layers/meta-selinux/ \
   ${OEROOT}/layers/meta-security/ \


### PR DESCRIPTION
meta-optee recipes are old and no longer maintained. They were upstreamed to meta-arm sometime back. This change also has a corresponding PR in meta-ledge layer to update the bbappends to use the meta-arm optee recipes.