### PR TITLE
local.conf: Leverage exported cache variables if defined

### DIFF
--- a/setup-environment-internal
+++ b/setup-environment-internal
@@ -251,6 +251,15 @@ fi
 sha512sum "${MANIFESTS}"/setup-environment-internal 2>&1 > conf/checksum
 
 ln -sf "${MANIFESTS}"/conf/local.conf conf/local.conf
+
+if [[ ! -z "${DL_DIR}" ]]; then
+	echo "DL_DIR = \"${DL_DIR}\"" >> conf/local.conf
+fi
+
+if [[ ! -z "${SSTATE_DIR}" ]]; then
+	echo "SSTATE_DIR = \"${SSTATE_DIR}\"" >> conf/local.conf
+fi
+
 ln -sf "${MANIFESTS}"/conf/bblayers.conf conf/bblayers.conf
 ln -sf "${MANIFESTS}"/README.md README.md
 if [ -d "${MANIFESTS}"/conf/multiconfig ]; then


### PR DESCRIPTION
Write DL_DIR and/or SSTATE_DIR to the local.conf if they exist as
environment variables.